### PR TITLE
Wip/extract path

### DIFF
--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -54,19 +54,28 @@ check the first two return values.)"
   (labels ((find-test ( key xml-form )
              ;; test whether the XML-FORM matches KEY
              (cond
-               ;; just the XML tag name
-               ((atom key)
-                (equal key (car xml-form)))
+               ;; just the XML tag name in key
+               ;; XML name is simple string
+               ((and (stringp key)
+                     (stringp (car xml-form)))
+                (string-equal key (car xml-form)))
 
-               ;; form (tag-name (attr-name attr-value))
+               ;; just the XML tag name in key
+               ;; XML name with namespace, form (string . namespace)
+               ((and (stringp key)
+                     (consp (car xml-form))
+                     (stringp (caar xml-form)))
+                (string-equal key (caar xml-form)))
+
+               ;; key form (tag-name (attr-name attr-value))
                (t
                 (and (find-test (car key) xml-form)
                      (find (cadr key) (cadr xml-form) :test #'equal)))))
 
            (descend ( key-list xml-form )
-             ;; recursive run down KEY-LIST.  If XML runs down to NIL before reaching
+             ;; recursive run down KEY-LIST.  If XML-FORM runs down to NIL before reaching
              ;; the end of KEY-LIST, it will be NIL at the end.  If not, what is
-             ;; remaining of XML is the found item.
+             ;; remaining of XML-FORM is the found item.
              (cond
                ;; KEY-LIST ends without dotted item, at the target XML form
                ((null (cdr key-list)) 

--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -52,6 +52,9 @@ When RESULT is non-NIL, the others are NIL. When result is NIL however, the othe
 In the case of complete failure, where even the very first item on KEY-LIST does not
 match the top XML form given, all three return values are NIL.  (It suffices to check
 the first two return values.)"
+  (when (typep xml 'node)
+    (setf xml
+          (node->nodelist xml)))
   (labels ((find-test ( key xml-form )
              ;; test whether the XML-FORM matches KEY
              (cond

--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -5,41 +5,49 @@
 ;; XML extraction tool
 
 (defun extract-path ( key-list xml )
-  "Extracts data from XML parse tree.  KEY-LIST is a path for descending down named
-objects in the argument XML.  For each path element, enclosed XML subforms are
-searched for a matching name.  Finally the whole last XML subform on the path is
-normally returned; however the symbol * may be added at the end of KEY-LIST to return
-list of all objects enclosed by the last subform on the path. KEY-LIST may be dotted
-as explained below to return XML tag attributes from the last subform on the path.
+  "Extracts data from XML parse tree.  KEY-LIST is a path for descending down
+named objects in the XML parse tree.  For each KEY-LIST element, XML subforms
+are searched for a matching tag name.  Finally the whole last XML subform on the
+path is normally returned if found; however the symbol * may be added at the end
+of KEY-LIST to return list of all objects /enclosed/ by the last subform on
+KEY-LIST. Also KEY-LIST may be dotted as explained below to return XML tag
+attributes from the last subform on KEY-LIST.
 
-XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
-        (tag-name (attributes-list) subform*)
+XML is to have the forms as returned by PARSE-TO-LIST or PARSE:
+        (tag-name (attributes-list) subform*),
+        ((tag-name . name-space) (attributes-list) subform*), or
+        #s(node :name tag-name
+                :ns name-space
+                :attrs attributes-list
+                :children subform*)
 
-The first element in KEY-LIST must match the top level form in the XML.  Subsequently
-each element in the KEY-LIST is to match the name of a subform.
+The first element in KEY-LIST must match the top level form in XML.
+Subsequently each element in the KEY-LIST is to match a subform.
 
-An element of KEY-LIST may be a string atom.  In that case the first subform with
-tag name matching the string is matched.  An element of KEY-LIST may also be a list of
-string atoms in this format:
-        (tag-name (attribute-name attribute-value))
+An element of KEY-LIST may be a string atom.  In that case the first subform
+with tag-name matching the string is matched.  An element of KEY-LIST may also
+be a list of string atoms in this format:
+        (tag-name (attribute-name attribute-value) ...)
 
-The first subform with name matching TAG-NAME and having an attribute matching
-ATTRIBUTE-NAME with value matching ATTRIBUTE-VALUE is matched.
+The first subform with name matching TAG-NAME /and/ having attributes matching
+attribute-names and attribute-values is matched.  Zero or more attribute/value
+pairs may be given.
 
-Normally the whole subform matching last element in KEY-LIST is returned.  The symbol
-* can be the last element of KEY-LIST to return list of all subforms enclosed by last
-matched form.  Attributes of last matched subform may be searched by ending KEY-LIST
-in dot notation, in which case the string after dot matches an attribute name.  The
-two element list of attribute name and value is returned.  * may be used after dot to
-return the whole attribute list.
+Normally the whole subform matching last element in KEY-LIST is returned.  The
+symbol * can be the last element of KEY-LIST to return list of all subforms
+enclosed by the last matched form.  Attributes of last matched subform may be
+searched by ending KEY-LIST in dot notation, in which case the string after dot
+matches an attribute name.  The two element list of attribute name and value is
+returned. The symbol * may be used after dot to return the whole attribute list.
 
-In the case where the search fails NIL is returned.  However it is possible that the
-search partially succeeds down the key path.  Three values are returned altogether
-and the state of the 2nd and 3rd values gives information about how much of KEY-LIST
-was matched, and at what point in XML:
+In the case where the search fails NIL is returned.  However it is possible that
+the search partially succeeds down the key path.  Three values are returned
+altogether and the 2nd and 3rd values give information about how much of
+KEY-LIST was matched, and at what point in XML:
         (values RESULT  KEY-LIST-FRAGMENT  XML-FRAGMENT)
 
-When RESULT is non-NIL, the others are NIL. When result is NIL however, the others are:
+When RESULT is non-NIL, the others are NIL. When result is NIL however, the
+others are:
         XML-FRAGMENT
           The last XML form that /did/ match in the key list.  It matches the first
           element of KEY-LIST-FRAGMENT.
@@ -52,7 +60,19 @@ When RESULT is non-NIL, the others are NIL. When result is NIL however, the othe
 In the case of complete failure, where even the very first item on KEY-LIST does not
 match the top XML form given, all three return values are NIL.  (It suffices to check
 the first two return values.)"
-  (labels ((find-test ( key xml-form )
+  (labels ((attribs-match-p ( key-attribs-list xml-attribs-list )
+             ;; search for (attr-name attr-value) pairs from KEY-ATTRIBS-LIST on
+             ;; XML-ATTRIBS-LIST.  true if all key pairs found.
+             (loop
+                :with attribs-match-var := t
+                :for attrib-key-pair  :in key-attribs-list
+                :do
+                  (setq attribs-match-var
+                        (and attribs-match-var
+                             (find attrib-key-pair xml-attribs-list :test #'equal)))
+                :finally (return attribs-match-var)))
+
+           (find-test ( key xml-form )
              ;; test whether the XML-FORM matches KEY
              (cond
                ;; just the XML tag name in key
@@ -61,10 +81,9 @@ the first two return values.)"
                      (stringp (xmlrep-tag xml-form)))
                 (string-equal key (xmlrep-tag xml-form)))
 
-               ;; key form (tag-name (attr-name attr-value))
-               (t
-                (and (find-test (car key) xml-form)
-                     (find (cadr key) (xmlrep-attribs xml-form) :test #'equal)))))
+               ;; key form (tag-name (attr-name attr-value) ...)
+               ((and (find-test (car key) xml-form)
+                     (attribs-match-p (cdr key) (xmlrep-attribs xml-form))))))
 
            (descend ( key-list xml-form )
              ;; recursive run down KEY-LIST.  If XML-FORM runs down to NIL before reaching

--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -1,123 +1,16 @@
-;;(declaim (optimize (speed 0) (space 0) (debug 3) (safety 3) (compilation-speed 0)))
+;; (declaim (optimize (speed 0) (space 0) (debug 3) (safety 3) (compilation-speed 0)))
 
 (in-package :xmls)
 
 ;; XML extraction tool
 
-(defun extract-path-list ( key-list xml )
-  "Extracts data from XML s-exp style parse tree.  KEY-LIST is a path for
-descending down named objects in the argument XML.  For each path element, enclosed
-XML subforms are searched for a matching name.  Finally the whole last XML subform on
-the path is normally returned; however the symbol * may be added at the end of
-KEY-LIST to return list of all objects enclosed by the last subform on the
-path. KEY-LIST may be dotted as explained below to return XML tag attributes from the
-last subform on the path.
-
-XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
-        (tag-name (attributes-list) subform*)
-
-The first element in KEY-LIST must match the top level form in the XML.  Subsequently
-each element in the KEY-LIST is to match the name of a subform.
-
-An element of KEY-LIST may be a string atom.  In that case the first subform with
-tag name matching the string is matched.  An element of KEY-LIST may also be a list of
-string atoms in this format:
-        (tag-name (attribute-name attribute-value))
-
-The first subform with name matching TAG-NAME and having an attribute matching
-ATTRIBUTE-NAME with value matching ATTRIBUTE-VALUE is matched.
-
-Normally the whole subform matching last element in KEY-LIST is returned.  The symbol
-* can be the last element of KEY-LIST to return list of all subforms enclosed by last
-matched form.  Attributes of last matched subform may be searched by ending KEY-LIST
-in dot notation, in which case the string after dot matches an attribute name.  The
-two element list of attribute name and value is returned.  * may be used after dot to
-return the whole attribute list.
-
-In the case where the search fails NIL is returned.  However it is possible that the
-search partially succeeds down the key path.  Three values are returned altogether
-and the state of the 2nd and 3rd values gives information about how much of KEY-LIST
-was matched, and at what point in XML:
-        (values RESULT  KEY-LIST-FRAGMENT  XML-FRAGMENT)
-
-When RESULT is non-NIL, the others are NIL. When result is NIL however, the others are:
-        XML-FRAGMENT
-          The last XML form that /did/ match in the key list.  It matches the first
-          element of KEY-LIST-FRAGMENT.
-
-        KEY-LIST-FRAGMENT
-          The /remaining/ part of the KEY-LIST that did not succeed.  However the
-          /first/ item on KEY-LIST-FRAGMENT matches the XML-FRAGMENT returned.  The
-          failure is at the second item on KEY-LIST-FRAGMENT.
-
-In the case of complete failure, where even the very first item on KEY-LIST does not
-match the top XML form given, all three return values are NIL.  (It suffices to check
-the first two return values.)"
-  (labels ((find-test ( key xml-form )
-             ;; test whether the XML-FORM matches KEY
-             (cond
-               ;; just the XML tag name in key
-               ;; XML name is simple string
-               ((and (stringp key)
-                     (stringp (car xml-form)))
-                (string-equal key (car xml-form)))
-
-               ;; just the XML tag name in key
-               ;; XML name with namespace, form (string . namespace)
-               ((and (stringp key)
-                     (consp (car xml-form))
-                     (stringp (caar xml-form)))
-                (string-equal key (caar xml-form)))
-
-               ;; key form (tag-name (attr-name attr-value))
-               (t
-                (and (find-test (car key) xml-form)
-                     (find (cadr key) (cadr xml-form) :test #'equal)))))
-
-           (descend ( key-list xml-form )
-             ;; recursive run down KEY-LIST.  If XML-FORM runs down to NIL before reaching
-             ;; the end of KEY-LIST, it will be NIL at the end.  If not, what is
-             ;; remaining of XML-FORM is the found item.
-             (cond
-               ;; KEY-LIST ends without dotted item, at the target XML form
-               ((null (cdr key-list))
-                (values xml-form nil nil))
-
-               ;; dotted item at the end of KEY-LIST, search attribute list of target XML form
-               ((atom (cdr key-list))
-                (if (eq '* (cdr key-list))
-                    (values (cadr xml-form) nil nil)
-                    (find (cdr key-list) (cadr xml-form) :test (lambda (key item) (equal key (car item))))))
-
-               ;; more tag names to match on KEY-LIST
-               ('t
-                (if (eq '* (cadr key-list))
-                    (values (cddr xml-form) nil nil)
-                    (let ((selected-xml-form (find (cadr key-list) (cddr xml-form) :test #'find-test)))
-                      (if selected-xml-form
-                          (descend (cdr key-list) selected-xml-form)
-
-                          ;; no matching sub-form, indicate what part of KEY-LIST did not match
-                          (values nil key-list xml-form))))))))
-
-    ;; empty list, degenerate usage
-    (when (null key-list)
-      (error "KEY-LIST is empty."))
-
-    ;; search down after initial match
-    (if (find-test (car key-list) xml)
-        (descend  key-list xml)
-        (values nil nil nil))))
-
-
 (defun extract-path ( key-list xml )
-  "Extracts data from XML node structure parse tree.  KEY-LIST is a path for
-descending down named objects in the argument XML.  For each path element, enclosed
-XML subforms are searched for a matching name.  Finally the whole last XML subform on
-the path is normally returned; however the symbol * may be added at the end of
-KEY-LIST to return list of all objects enclosed by the last subform on the
-path. KEY-LIST may be dotted as explained below to return XML tag attributes from the
-last subform on the path.
+  "Extracts data from XML parse tree.  KEY-LIST is a path for descending down named
+objects in the argument XML.  For each path element, enclosed XML subforms are
+searched for a matching name.  Finally the whole last XML subform on the path is
+normally returned; however the symbol * may be added at the end of KEY-LIST to return
+list of all objects enclosed by the last subform on the path. KEY-LIST may be dotted
+as explained below to return XML tag attributes from the last subform on the path.
 
 XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
         (tag-name (attributes-list) subform*)
@@ -165,13 +58,13 @@ the first two return values.)"
                ;; just the XML tag name in key
                ;; XML name is simple string
                ((and (stringp key)
-                     (stringp (node-name xml-form)))
-                (string-equal key (node-name xml-form)))
+                     (stringp (xmlrep-tag xml-form)))
+                (string-equal key (xmlrep-tag xml-form)))
 
                ;; key form (tag-name (attr-name attr-value))
                (t
                 (and (find-test (car key) xml-form)
-                     (find (cadr key) (node-attrs xml-form) :test #'equal)))))
+                     (find (cadr key) (xmlrep-attribs xml-form) :test #'equal)))))
 
            (descend ( key-list xml-form )
              ;; recursive run down KEY-LIST.  If XML-FORM runs down to NIL before reaching
@@ -185,14 +78,16 @@ the first two return values.)"
                ;; dotted item at the end of KEY-LIST, search attribute list of target XML form
                ((atom (cdr key-list))
                 (if (eq '* (cdr key-list))
-                    (values (node-attrs xml-form) nil nil)
-                    (find (cdr key-list) (node-attrs xml-form) :test (lambda (key item) (equal key (car item))))))
+                    (values (xmlrep-attribs xml-form) nil nil)
+                    (find (cdr key-list)  (xmlrep-attribs xml-form)
+                          :test (lambda (key item) (equal key (car item))))))
 
                ;; more tag names to match on KEY-LIST
                ('t
                 (if (eq '* (cadr key-list))
-                    (values (node-children xml-form) nil nil)
-                    (let ((selected-xml-form (find (cadr key-list) (node-children xml-form) :test #'find-test)))
+                    (values (xmlrep-children xml-form) nil nil)
+                    (let ((selected-xml-form (find (cadr key-list)  (xmlrep-children xml-form)
+                                                   :test #'find-test)))
                       (if selected-xml-form
                           (descend (cdr key-list) selected-xml-form)
 

--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -1,0 +1,99 @@
+;;(declaim (optimize (speed 0) (space 0) (debug 3) (safety 3) (compilation-speed 0)))
+
+(in-package :xmls)
+
+;; XML extraction tool
+
+(defun extract-path ( key-list xml )
+  "Extracts data from XML parse tree.  KEY-LIST is a path for descending down named
+objects in the argument XML.  For each path element, inner XML data objects are searched for a
+matching name.  Finally the whole last matching object is normally returned; however
+the symbol * may be added at the end of KEY-LIST to return list of all objects
+enclosed by the last matching object. KEY-LIST may be dotted as explained below to
+finally return XML tag attributes.
+
+XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
+        (tag-name (attributes-list) subform*)
+
+The top level tag name in the XML node list must be matched by the start of KEY-LIST.
+Subsequently each element in the KEY-LIST is to match the name of a subform.
+
+An element of KEY-LIST may be a string atom.  In that case the first subform with
+tagname matching the string is matched.  An element of KEY-LIST may also be a list of
+string atoms in this form:
+        (tag-name (attribute-name attribute-value))
+
+The first subform with name matching TAG-NAME and having an attribute matching
+ATTRIBUTE-NAME with value matching ATTRIBUTE-VALUE is matched.
+
+Normally the whole subform matching last element in KEY-LIST is returned.  The symbol
+* can be the last element of KEY-LIST to return list of all subforms enclosed by last
+matched form.  Attributes of last matched subform may be searched by ending KEY-LIST
+in dot notation, in which case the string after dot matches an attribute name.  The
+two element list of attribute name and value is returned.  * may be used after dot to
+return the whole attribute list.
+
+In the case where the search fails NIL is returned.  However it is possible that the
+search partially succeeds down the key path.  Three values are returned altogether
+and the state of the 2nd and 3rd values gives information about how much of KEY-LIST
+was matched, and at what point in XML:
+        (values RESULT  KEY-LIST-FRAGMENT  XML-FRAGMENT)
+
+When RESULT is non-NIL, the others are NIL. When result is NIL however, the others are:
+        XML-FRAGMENT       the last XML form that /did/ match in the key list.  There
+          may be useful information in the form, especially in the attributes.
+
+        KEY-LIST-FRAGMENT  the /remaining/ part of the KEY-LIST that did not succeed.
+          However the /first/ item on KEY-LIST-FRAGMENT is the item that /did/ match
+          the XML-FRAGMENT returned.  The fail is at the second item on KEY-LIST-
+          FRAGMENT.
+
+To differentiate the case of complete failure, where even the very first item on KEY-
+LIST does not match the form given, all three return values are NIL.  (It suffices to
+check the first two return values.)"
+  (labels ((find-test ( key xml-form )
+             ;; test whether the XML-FORM matches KEY
+             (cond
+               ;; just the XML tag name
+               ((atom key)
+                (equal key (car xml-form)))
+
+               ;; form (tag-name (attr-name attr-value))
+               (t
+                (and (find-test (car key) xml-form)
+                     (find (cadr key) (cadr xml-form) :test #'equal)))))
+
+           (descend ( key-list xml-form )
+             ;; recursive run down KEY-LIST.  If XML runs down to NIL before reaching
+             ;; the end of KEY-LIST, it will be NIL at the end.  If not, what is
+             ;; remaining of XML is the found item.
+             (cond
+               ;; KEY-LIST ends without dotted item, at the target XML form
+               ((null (cdr key-list)) 
+                (values xml-form nil nil))
+
+               ;; dotted item at the end of KEY-LIST, search attribute list of target XML form
+               ((atom (cdr key-list))
+                (if (eq '* (cdr key-list))
+                    (values (cadr xml-form) nil nil)
+                    (find (cdr key-list) (cadr xml-form) :test (lambda (key item) (equal key (car item))))))
+
+               ;; more tag names to match on KEY-LIST
+               ('t
+                (if (eq '* (cadr key-list))
+                    (values (cddr xml-form) nil nil)
+                    (let ((selected-xml-form (find (cadr key-list) (cddr xml-form) :test #'find-test)))
+                      (if selected-xml-form
+                          (descend (cdr key-list) selected-xml-form)
+
+                          ;; no matching sub-form, indicate what part of KEY-LIST did not match
+                          (values nil key-list xml-form))))))))
+        
+    ;; empty list, degenerate usage
+    (when (null key-list)
+      (error "KEY-LIST is empty."))
+
+    ;; search down after initial match
+    (if (find-test (car key-list) xml)
+        (descend  key-list xml)
+        (values nil nil nil))))

--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -4,13 +4,14 @@
 
 ;; XML extraction tool
 
-(defun extract-path ( key-list xml )
-  "Extracts data from XML parse tree.  KEY-LIST is a path for descending down named
-objects in the argument XML.  For each path element, enclosed XML subforms are
-searched for a matching name.  Finally the whole last XML subform on the path is
-normally returned; however the symbol * may be added at the end of KEY-LIST to return
-list of all objects enclosed by the last subform on the path. KEY-LIST may be dotted
-as explained below to return XML tag attributes from the last subform on the path.
+(defun extract-path-list ( key-list xml )
+  "Extracts data from XML s-exp style parse tree.  KEY-LIST is a path for
+descending down named objects in the argument XML.  For each path element, enclosed
+XML subforms are searched for a matching name.  Finally the whole last XML subform on
+the path is normally returned; however the symbol * may be added at the end of
+KEY-LIST to return list of all objects enclosed by the last subform on the
+path. KEY-LIST may be dotted as explained below to return XML tag attributes from the
+last subform on the path.
 
 XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
         (tag-name (attributes-list) subform*)
@@ -52,9 +53,6 @@ When RESULT is non-NIL, the others are NIL. When result is NIL however, the othe
 In the case of complete failure, where even the very first item on KEY-LIST does not
 match the top XML form given, all three return values are NIL.  (It suffices to check
 the first two return values.)"
-  (when (typep xml 'node)
-    (setf xml
-          (node->nodelist xml)))
   (labels ((find-test ( key xml-form )
              ;; test whether the XML-FORM matches KEY
              (cond
@@ -82,7 +80,7 @@ the first two return values.)"
              ;; remaining of XML-FORM is the found item.
              (cond
                ;; KEY-LIST ends without dotted item, at the target XML form
-               ((null (cdr key-list)) 
+               ((null (cdr key-list))
                 (values xml-form nil nil))
 
                ;; dotted item at the end of KEY-LIST, search attribute list of target XML form
@@ -101,7 +99,106 @@ the first two return values.)"
 
                           ;; no matching sub-form, indicate what part of KEY-LIST did not match
                           (values nil key-list xml-form))))))))
-        
+
+    ;; empty list, degenerate usage
+    (when (null key-list)
+      (error "KEY-LIST is empty."))
+
+    ;; search down after initial match
+    (if (find-test (car key-list) xml)
+        (descend  key-list xml)
+        (values nil nil nil))))
+
+
+(defun extract-path ( key-list xml )
+  "Extracts data from XML node structure parse tree.  KEY-LIST is a path for
+descending down named objects in the argument XML.  For each path element, enclosed
+XML subforms are searched for a matching name.  Finally the whole last XML subform on
+the path is normally returned; however the symbol * may be added at the end of
+KEY-LIST to return list of all objects enclosed by the last subform on the
+path. KEY-LIST may be dotted as explained below to return XML tag attributes from the
+last subform on the path.
+
+XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
+        (tag-name (attributes-list) subform*)
+
+The first element in KEY-LIST must match the top level form in the XML.  Subsequently
+each element in the KEY-LIST is to match the name of a subform.
+
+An element of KEY-LIST may be a string atom.  In that case the first subform with
+tag name matching the string is matched.  An element of KEY-LIST may also be a list of
+string atoms in this format:
+        (tag-name (attribute-name attribute-value))
+
+The first subform with name matching TAG-NAME and having an attribute matching
+ATTRIBUTE-NAME with value matching ATTRIBUTE-VALUE is matched.
+
+Normally the whole subform matching last element in KEY-LIST is returned.  The symbol
+* can be the last element of KEY-LIST to return list of all subforms enclosed by last
+matched form.  Attributes of last matched subform may be searched by ending KEY-LIST
+in dot notation, in which case the string after dot matches an attribute name.  The
+two element list of attribute name and value is returned.  * may be used after dot to
+return the whole attribute list.
+
+In the case where the search fails NIL is returned.  However it is possible that the
+search partially succeeds down the key path.  Three values are returned altogether
+and the state of the 2nd and 3rd values gives information about how much of KEY-LIST
+was matched, and at what point in XML:
+        (values RESULT  KEY-LIST-FRAGMENT  XML-FRAGMENT)
+
+When RESULT is non-NIL, the others are NIL. When result is NIL however, the others are:
+        XML-FRAGMENT
+          The last XML form that /did/ match in the key list.  It matches the first
+          element of KEY-LIST-FRAGMENT.
+
+        KEY-LIST-FRAGMENT
+          The /remaining/ part of the KEY-LIST that did not succeed.  However the
+          /first/ item on KEY-LIST-FRAGMENT matches the XML-FRAGMENT returned.  The
+          failure is at the second item on KEY-LIST-FRAGMENT.
+
+In the case of complete failure, where even the very first item on KEY-LIST does not
+match the top XML form given, all three return values are NIL.  (It suffices to check
+the first two return values.)"
+  (labels ((find-test ( key xml-form )
+             ;; test whether the XML-FORM matches KEY
+             (cond
+               ;; just the XML tag name in key
+               ;; XML name is simple string
+               ((and (stringp key)
+                     (stringp (node-name xml-form)))
+                (string-equal key (node-name xml-form)))
+
+               ;; key form (tag-name (attr-name attr-value))
+               (t
+                (and (find-test (car key) xml-form)
+                     (find (cadr key) (node-attrs xml-form) :test #'equal)))))
+
+           (descend ( key-list xml-form )
+             ;; recursive run down KEY-LIST.  If XML-FORM runs down to NIL before reaching
+             ;; the end of KEY-LIST, it will be NIL at the end.  If not, what is
+             ;; remaining of XML-FORM is the found item.
+             (cond
+               ;; KEY-LIST ends without dotted item, at the target XML form
+               ((null (cdr key-list))
+                (values xml-form nil nil))
+
+               ;; dotted item at the end of KEY-LIST, search attribute list of target XML form
+               ((atom (cdr key-list))
+                (if (eq '* (cdr key-list))
+                    (values (node-attrs xml-form) nil nil)
+                    (find (cdr key-list) (node-attrs xml-form) :test (lambda (key item) (equal key (car item))))))
+
+               ;; more tag names to match on KEY-LIST
+               ('t
+                (if (eq '* (cadr key-list))
+                    (values (node-children xml-form) nil nil)
+                    (let ((selected-xml-form (find (cadr key-list) (node-children xml-form) :test #'find-test)))
+                      (if selected-xml-form
+                          (descend (cdr key-list) selected-xml-form)
+
+                          ;; no matching sub-form, indicate what part of KEY-LIST did not match
+                          (values nil key-list xml-form))))))))
+
     ;; empty list, degenerate usage
     (when (null key-list)
       (error "KEY-LIST is empty."))

--- a/extract-path.lisp
+++ b/extract-path.lisp
@@ -6,21 +6,21 @@
 
 (defun extract-path ( key-list xml )
   "Extracts data from XML parse tree.  KEY-LIST is a path for descending down named
-objects in the argument XML.  For each path element, inner XML data objects are searched for a
-matching name.  Finally the whole last matching object is normally returned; however
-the symbol * may be added at the end of KEY-LIST to return list of all objects
-enclosed by the last matching object. KEY-LIST may be dotted as explained below to
-finally return XML tag attributes.
+objects in the argument XML.  For each path element, enclosed XML subforms are
+searched for a matching name.  Finally the whole last XML subform on the path is
+normally returned; however the symbol * may be added at the end of KEY-LIST to return
+list of all objects enclosed by the last subform on the path. KEY-LIST may be dotted
+as explained below to return XML tag attributes from the last subform on the path.
 
 XML has the parse form as returned by XMLS:PARSE-TO-LIST or XMLS:NODE->NODELIST:
         (tag-name (attributes-list) subform*)
 
-The top level tag name in the XML node list must be matched by the start of KEY-LIST.
-Subsequently each element in the KEY-LIST is to match the name of a subform.
+The first element in KEY-LIST must match the top level form in the XML.  Subsequently
+each element in the KEY-LIST is to match the name of a subform.
 
 An element of KEY-LIST may be a string atom.  In that case the first subform with
-tagname matching the string is matched.  An element of KEY-LIST may also be a list of
-string atoms in this form:
+tag name matching the string is matched.  An element of KEY-LIST may also be a list of
+string atoms in this format:
         (tag-name (attribute-name attribute-value))
 
 The first subform with name matching TAG-NAME and having an attribute matching
@@ -40,17 +40,18 @@ was matched, and at what point in XML:
         (values RESULT  KEY-LIST-FRAGMENT  XML-FRAGMENT)
 
 When RESULT is non-NIL, the others are NIL. When result is NIL however, the others are:
-        XML-FRAGMENT       the last XML form that /did/ match in the key list.  There
-          may be useful information in the form, especially in the attributes.
+        XML-FRAGMENT
+          The last XML form that /did/ match in the key list.  It matches the first
+          element of KEY-LIST-FRAGMENT.
 
-        KEY-LIST-FRAGMENT  the /remaining/ part of the KEY-LIST that did not succeed.
-          However the /first/ item on KEY-LIST-FRAGMENT is the item that /did/ match
-          the XML-FRAGMENT returned.  The fail is at the second item on KEY-LIST-
-          FRAGMENT.
+        KEY-LIST-FRAGMENT
+          The /remaining/ part of the KEY-LIST that did not succeed.  However the
+          /first/ item on KEY-LIST-FRAGMENT matches the XML-FRAGMENT returned.  The
+          failure is at the second item on KEY-LIST-FRAGMENT.
 
-To differentiate the case of complete failure, where even the very first item on KEY-
-LIST does not match the form given, all three return values are NIL.  (It suffices to
-check the first two return values.)"
+In the case of complete failure, where even the very first item on KEY-LIST does not
+match the top XML form given, all three return values are NIL.  (It suffices to check
+the first two return values.)"
   (labels ((find-test ( key xml-form )
              ;; test whether the XML-FORM matches KEY
              (cond

--- a/fiveam-tests.lisp
+++ b/fiveam-tests.lisp
@@ -54,3 +54,50 @@
 					    (xmls:parse "<?xml version=\"1.0\"?> <text:list-style style:name=\"L1\"></text:list-style>"))
 			 :attr-ns))))
 
+(def-fixture parsed-article ()
+  (let ((node
+          (with-open-file (str (asdf:system-relative-pathname "xmls" "tests/nxml/genetics-article.xml")
+                               :direction :input)
+            (xmls:parse-to-list str))))
+    (&body)))
+
+(test check-extract-path
+  (with-fixture parsed-article ()
+    ;; retrieve first of items matching the path
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" "ref")
+                                     node)))
+      (is (= 4 (length result)))
+      (is (equalp (nth 0 result)
+                  '("ref" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle")))
+      (is (equalp (nth 1 result)
+                  '(("id" "gkt903-B1")))))
+
+    ;; retrieve tag attributes of first item matching the path
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" "ref" . *)
+                                     node)))
+      (is (equalp result
+                  '(("id" "gkt903-B1")))))
+
+    ;; retrieve all items enclosed by element matching the path
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" *)
+                                     node)))
+      (is (= 41 (length result)))
+      (is (equalp (nth 0 result)
+                  '(("title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") nil "REFERENCES")))
+      (is (equalp (nth 1 (nth 1 result))
+                  '(("id" "gkt903-B1"))))
+      (is (equalp (nth 1 (nth 15 result))
+                  '(("id" "gkt903-B15")))))
+
+    ;; select specific item among several with same tag based on tag attributes
+    ;; here selecting on "ref" in the path...
+    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                       "back" "ref-list" ("ref" ("id" "gkt903-B15")) "element-citation"
+                                       "article-title")
+                                     node)))
+      (is (equalp result
+                  '(("article-title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") NIL
+                    "HNS, a nuclearcytoplasmic shuttling sequence in HuR"))))))

--- a/fiveam-tests.lisp
+++ b/fiveam-tests.lisp
@@ -64,9 +64,9 @@
 (test check-extract-path
   (with-fixture parsed-article ()
     ;; retrieve first of items matching the path
-    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
-                                       "back" "ref-list" "ref")
-                                     node)))
+    (let ((result (xmls:extract-path-list '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                            "back" "ref-list" "ref")
+                                          node)))
       (is (= 4 (length result)))
       (is (equalp (nth 0 result)
                   '("ref" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle")))
@@ -74,16 +74,16 @@
                   '(("id" "gkt903-B1")))))
 
     ;; retrieve tag attributes of first item matching the path
-    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
-                                       "back" "ref-list" "ref" . *)
-                                     node)))
+    (let ((result (xmls:extract-path-list '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                            "back" "ref-list" "ref" . *)
+                                          node)))
       (is (equalp result
                   '(("id" "gkt903-B1")))))
 
     ;; retrieve all items enclosed by element matching the path
-    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
-                                       "back" "ref-list" *)
-                                     node)))
+    (let ((result (xmls:extract-path-list '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                            "back" "ref-list" *)
+                                          node)))
       (is (= 41 (length result)))
       (is (equalp (nth 0 result)
                   '(("title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") nil "REFERENCES")))
@@ -94,10 +94,10 @@
 
     ;; select specific item among several with same tag based on tag attributes
     ;; here selecting on "ref" in the path...
-    (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
-                                       "back" "ref-list" ("ref" ("id" "gkt903-B15")) "element-citation"
-                                       "article-title")
-                                     node)))
+    (let ((result (xmls:extract-path-list '("OAI-PMH" "GetRecord" "record" "metadata" "article"
+                                            "back" "ref-list" ("ref" ("id" "gkt903-B15")) "element-citation"
+                                            "article-title")
+                                          node)))
       (is (equalp result
                   '(("article-title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") NIL
                     "HNS, a nuclearcytoplasmic shuttling sequence in HuR"))))))
@@ -115,18 +115,15 @@
     (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
                                        "back" "ref-list" "ref")
                                      node)))
-      (is (= 4 (length result)))
-      (is (equalp (nth 0 result)
-                  '("ref" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle")))
-      (is (equalp (nth 1 result)
-                  '(("id" "gkt903-B1")))))
+      (is (string= (node-name result) "ref"))
+      (is (string= (node-ns result) "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle"))
+      (is (equalp (node-attrs result) '(("id" "gkt903-B1")))))
 
     ;; retrieve tag attributes of first item matching the path
     (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
                                        "back" "ref-list" "ref" . *)
                                      node)))
-      (is (equalp result
-                  '(("id" "gkt903-B1")))))
+      (is (equalp result '(("id" "gkt903-B1")))))
 
     ;; retrieve all items enclosed by element matching the path
     (let ((result (xmls:extract-path '("OAI-PMH" "GetRecord" "record" "metadata" "article"
@@ -134,10 +131,13 @@
                                      node)))
       (is (= 41 (length result)))
       (is (equalp (nth 0 result)
-                  '(("title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") nil "REFERENCES")))
-      (is (equalp (nth 1 (nth 1 result))
+                  (make-node :name "title"
+                             :ns "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle"
+                             :attrs nil
+                             :children '("REFERENCES"))))
+      (is (equalp (node-attrs (nth 1 result))
                   '(("id" "gkt903-B1"))))
-      (is (equalp (nth 1 (nth 15 result))
+      (is (equalp (node-attrs (nth 15 result))
                   '(("id" "gkt903-B15")))))
 
     ;; select specific item among several with same tag based on tag attributes
@@ -147,5 +147,7 @@
                                        "article-title")
                                      node)))
       (is (equalp result
-                  '(("article-title" . "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle") NIL
-                    "HNS, a nuclearcytoplasmic shuttling sequence in HuR"))))))
+                  (make-node :name "article-title"
+                             :ns "http://dtd.nlm.nih.gov/2.0/xsd/archivearticle"
+                             :attrs NIL
+                             :children '("HNS, a nuclearcytoplasmic shuttling sequence in HuR")))))))

--- a/xmls.asd
+++ b/xmls.asd
@@ -26,6 +26,8 @@
                         #+asdf-unicode :encoding #+asdf-unicode :utf-8)
                  (:file "xmlrep-helpers"
                         ;; package is defined in XMLS. [2009/02/24:rpg]
+                        :depends-on ("xmls"))
+                 (:file "extract-path"
                         :depends-on ("xmls"))))
 
 (defsystem :xmls/test

--- a/xmls.asd
+++ b/xmls.asd
@@ -38,8 +38,8 @@
                 (error "Failed XMLS test.")))
   :depends-on (xmls))
 
-(defsystem xmls/unit-test
-    :depends-on (xmls fiveam)
+(defsystem :xmls/unit-test
+  :depends-on (xmls fiveam)
   :perform (test-op (op c)
               (declare (ignorable op c))
               (uiop:symbol-call :fiveam :run! (uiop:find-symbol* '#:xmls-test :xmls-test)))

--- a/xmls.lisp
+++ b/xmls.lisp
@@ -32,6 +32,7 @@
            xmlrep-boolean-attrib-value
 
            ;; tree searching from Daniel Eliason
+           extract-path-list
            extract-path
 
            ;;debugging

--- a/xmls.lisp
+++ b/xmls.lisp
@@ -31,6 +31,9 @@
            xmlrep-attrib-value
            xmlrep-boolean-attrib-value
 
+           ;; tree searching from Daniel Eliason
+           extract-path
+
            ;;debugging
            debug-on debug-off))
 


### PR DESCRIPTION
Hi Robert, I finally got my act together and put a first set of changes into XMLS.  I set up some tests both for integration and also for example usage of EXTRACT-PATH.  I've always used the list representation, so I wonder if next I should consider: 1) how to adapt the concept to the structure based node representation.  2) whether to extend the tag attribute match to allow more than one tag.  Any suggestion?  Thanks!
-Daniel E.