### PR TITLE
Preserve namespace prefix for attribute QName via a plist

### DIFF
--- a/fiveam-tests.lisp
+++ b/fiveam-tests.lisp
@@ -48,3 +48,9 @@
     (is (equal (list "profile" "profile" "profile")
                (mapcar #'xmlrep-tag (xmlrep-children node))))))
 
+(test attribute-with-prefixed-name
+      (is (string= "style"
+		   (getf (xmls::find-attrib "name"
+					    (xmls:parse "<?xml version=\"1.0\"?> <text:list-style style:name=\"L1\"></text:list-style>"))
+			 :attr-ns))))
+

--- a/xmls.lisp
+++ b/xmls.lisp
@@ -551,7 +551,7 @@ character translation."
 	 ;; If SUFFIX is true, then NAME is Prefix and SUFFIX is
 	 ;; LocalPart.
 	 (if suffix
-	     (list 'attr suffix val :ns name)
+	     (list 'attr suffix val :attr-ns name)
 	     (list 'attr name val))))))
 
 (defrule ws ()

--- a/xmls.lisp
+++ b/xmls.lisp
@@ -546,8 +546,13 @@ character translation."
          (setf val (match* attr-text-sq))
          (match #\'))))
       t)
-     (if (string= "xmlns" name) (list 'nsdecl suffix val) (list
-                                                           'attr (or suffix name) val)))))
+     (if (string= "xmlns" name)
+	 (list 'nsdecl suffix val)
+	 ;; If SUFFIX is true, then NAME is Prefix and SUFFIX is
+	 ;; LocalPart.
+	 (if suffix
+	     (list 'attr suffix val :ns name)
+	     (list 'attr name val))))))
 
 (defrule ws ()
   (and (match+ ws-char)


### PR DESCRIPTION
Regarding #5, as QNAME is used in quite a few places, the least disruptive starting point might be modification of ATTR-OR-NSDECL to use, as you suggested, a plist following the attribute value.

    > (xmls:parse "<?xml version=\"1.0\"?> <text:list-style style:name=\"L1\"></text:list-style>")

    #S(XMLS:NODE
       :NAME "list-style"
       :NS "text"
       :ATTRS (("name" "L1" :NS "style"))
       :CHILDREN NIL)

    > (xmls:node-attrs (xmls:parse "<?xml version=\"1.0\"?> <text:list-style style:name=\"L1\"></text:list-style>"))
    (("name" "L1" :NS "style"))


No complaints from the test suite:

    Running test suite XMLS-TEST
     Running test CHECK-CDATA-BACKTRACK .
     Running test BIGGER-CHECK-CDATA-BACKTRACK .
     Running test SIMPLE-NODELIST-TRANSLATOR .
     Running test CHECK-ACCESSORS ....
     Running test CHECK-XMLREP-ACCESSORS ....
     Did 11 checks.
	Pass: 11 (100%)
	Skip: 0 ( 0%)
	Fail: 0 ( 0%)

    Script succeeded
    ;;; Testing XMLS/OCTETS.
    Script succeeded
    ASDF test output code is: 0
    Done running ASDF tests.
