### PR TITLE
When there is no content to parse, return NIL from XMLS:PARSE.

### DIFF
--- a/fiveam-tests.lisp
+++ b/fiveam-tests.lisp
@@ -11,6 +11,22 @@
 
 (in-suite xmls-test)
 
+(test parse-empty-document
+  (null (parse "")))
+
+(test parse-whitespace-document
+  (null (parse "    ")))
+
+(test parse-multiple-top-level-document
+  (with-input-from-string (s "<a>1</a><b>2</b><c>3</c><c>4</c><c>5</c><c>6</c>")
+    (is (equalp (make-node :name "a" :children '("1")) (parse s)))
+    (is (equalp (make-node :name "b" :children '("2")) (parse s)))
+    (is (equalp (make-node :name "c" :children '("3")) (parse s)))
+    (is (equalp (make-node :name "c" :children '("4")) (parse s)))
+    (is (equalp (make-node :name "c" :children '("5")) (parse s)))
+    (is (equalp (make-node :name "c" :children '("6")) (parse s)))
+    (null (parse s))))
+
 (test check-cdata-backtrack
   (is (equalp (make-node :name "name" :children (list "x]"))
               (parse "<name><![CDATA[x]]]></name>"))))

--- a/xmls.lisp
+++ b/xmls.lisp
@@ -371,7 +371,7 @@ character translation."
 (defmacro match (&rest matchers)
   "Attempts to match the next input character with one of the supplied matchers."
   `(let ((c (peek-stream (state-stream s))))
-    (and
+    (and c
      (or ,@(loop for m in matchers
                  collect (etypecase m
                            (standard-char `(char= ,m c))


### PR DESCRIPTION
This is the behavior stated by README.html.

Define additional test cases for the new behavior.

This commit fixes https://github.com/rpgoldman/xmls/issues/14: "Working with empty document"

This commit implements the patch that is shown in issue #14.