### PR TITLE
Fix the GitHub actions for regression testing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         lisp:
-          - ccl-bin
+          - ccl-bin/1.12.2
           # - allegro Allegro from Roswell can't load FiveAM from quicklisp
           - ecl
           # disable CMU because Roswell's trying to install an


### PR DESCRIPTION
There were a number of issues that piled up without my noticing from old versions of roswell and something causing roswell to install old versions of the lisps.